### PR TITLE
Ignore error info lint in avds return command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ buildbin:
 run: 
 	@go run main.go install ~/Desktop/app.apk
 run-dev:
-	@go run main.go instrumentation com.bandlab.bandlab.test
+	@go run main.go avds

--- a/adb/adbformatted.go
+++ b/adb/adbformatted.go
@@ -11,3 +11,13 @@ func ListPacakgesThirdPartyFormatted() PackageListCommandRetrun {
 		"package:",
 	)}
 }
+
+// List down AVD(s) and ignore other data not related to it such as
+// crash report path info
+func AvdListFormatted() AvdListCommandReturn {
+	commandReturn := AvdList()
+	if commandReturn.Error != nil {
+		return AvdListCommandReturn{Error: commandReturn.Error}
+	}
+	return AvdListCommandReturn{AvdList: splitAvdList(string(commandReturn.Output))}
+}

--- a/adb/helper.go
+++ b/adb/helper.go
@@ -13,3 +13,17 @@ func splitPackageList(rawString string, trimmedPrefix string) []string {
 
 	return packages
 }
+
+func splitAvdList(rawString string) []string {
+	avds := strings.Split(strings.TrimSpace(rawString), "\n")
+
+	returnedAvds := []string{}
+
+	for _, avd := range avds {
+		if !strings.Contains(avd, "INFO") && !strings.Contains(avd, "|") {
+			returnedAvds = append(returnedAvds, avd)
+		}
+	}
+
+	return returnedAvds
+}

--- a/adb/structs.go
+++ b/adb/structs.go
@@ -11,3 +11,9 @@ type PackageListCommandRetrun struct {
 	PackageList []string
 	Error       error
 }
+
+// AvdListCommandReturn have list of AVD(s) and error
+type AvdListCommandReturn struct {
+	AvdList []string
+	Error   error
+}

--- a/cmd/avds.go
+++ b/cmd/avds.go
@@ -16,14 +16,16 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	adb "github.com/esafirm/gadb/adb"
 	pui "github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 )
 
+// Option: run wipe command to the selected AVD
 var isWipe bool
+
+// Option: run AVD in cold boot state
 var isColdBoot bool
 
 var avdsCmd = &cobra.Command{
@@ -55,17 +57,14 @@ func showAvdSelection() {
 }
 
 func showAvdsPrompt(caption string) string {
-	commandResult := adb.AvdList()
+	commandResult := adb.AvdListFormatted()
 	if commandResult.Error != nil {
 		panic(commandResult.Error)
 	}
 
-	avdList := strings.TrimSpace(string(commandResult.Output))
-	avdListSlice := strings.Split(avdList, "\n")
-
 	prompt := pui.Select{
 		Label: caption,
-		Items: avdListSlice,
+		Items: commandResult.AvdList,
 	}
 
 	_, result, err := prompt.Run()


### PR DESCRIPTION
## Previously

```
? Select AVD to run: 
  ▸ INFO    | Storing crashdata in: /tmp/android-esafirm/emu-crash-34.2.15.db, detection is enabled for process: 48243
  ▸ AVD 1
```

## Now

```
? Select AVD to run: 
  ▸ AVD 1
 ```